### PR TITLE
Fix for robot not being created 

### DIFF
--- a/Artifacts/configure/orch_setup.py
+++ b/Artifacts/configure/orch_setup.py
@@ -32,7 +32,10 @@ class CloudOrchHelper:
         self.login()
 
     def _getAbsoluteEndpoint(self, relative_endpoint):
-        return self.orch_url + relative_endpoint
+        if relative_endpoint.lstrip("/").startswith("odata"):
+            return f"{self.orch_url}/{self.account_name}/{self.service_logical_name}/{relative_endpoint.lstrip("/")}"
+        else:
+            return f"{self.orch_url} + relative_endpoint
 
     def _get_access_token(self):
         body = {"grant_type": "refresh_token",
@@ -145,7 +148,7 @@ class CloudOrchHelper:
                 "userCreateRequestDtoList": [
                     {
                         "emailId": user_email,
-                        "redirectUrl": self._getAbsoluteEndpoint(f"/{self.account_name}/portal_/loginwithguid")
+                        "redirectUrl": self._getAbsoluteEndpoint(f"/portal_/loginwithguid")
                     }
                 ],
                 "tenantRoleListMap": {
@@ -155,7 +158,7 @@ class CloudOrchHelper:
             }
         }
         r = requests.post(self._getAbsoluteEndpoint(
-            f"/{self.account_name}/portal_/api/users/inviteUsers"), headers=headers, json=body)
+            f"/portal_/api/users/inviteUsers"), headers=headers, json=body)
 
     def _get_user_id_tenant(self, user_email):
         r = self.get(f"/odata/Users/?$filter=EmailAddress eq '{user_email}'")
@@ -185,7 +188,8 @@ class CloudOrchHelper:
             f"/odata/Folders({folder_id})/UiPath.Server.Configuration.OData.RemoveUserFromFolder", body)
 
     def _get_folder_id(self, folder_name):
-        r = self.get(f"/odata/Folders?$filter=DisplayName eq '{folder_name}'")
+        r = self.get(
+            f"/odata/Folders?$filter=DisplayName eq '{folder_name}'")
         print(r.json())
         return r.json()['value'][0]['Id']
 

--- a/Artifacts/configure/orch_setup.py
+++ b/Artifacts/configure/orch_setup.py
@@ -423,7 +423,7 @@ def setup_dsf_folder(orchHelper, password, ms_account_user, ms_account_pw, proce
         "Name": "DSF_OrchURL",
         "ValueScope": "Global",
         "ValueType": "Text",
-        "StringValue": orchHelper.orch_url
+        "StringValue": orchHelper._getAbsoluteEndpoint("")
     })
 
 

--- a/Artifacts/configure/orch_setup.py
+++ b/Artifacts/configure/orch_setup.py
@@ -32,10 +32,11 @@ class CloudOrchHelper:
         self.login()
 
     def _getAbsoluteEndpoint(self, relative_endpoint):
-        if relative_endpoint.lstrip("/").startswith("odata"):
-            return f"{self.orch_url}/{self.account_name}/{self.service_logical_name}/{relative_endpoint.lstrip("/")}"
+        relative_endpoint = relative_endpoint.lstrip("/")
+        if relative_endpoint.startswith("odata"):
+            return f"{self.orch_url}/{self.account_name}/{self.service_logical_name}/{relative_endpoint}"
         else:
-            return f"{self.orch_url} + relative_endpoint
+            return f"{self.orch_url}/{relative_endpoint}"
 
     def _get_access_token(self):
         body = {"grant_type": "refresh_token",

--- a/vm/azuredeploy.json
+++ b/vm/azuredeploy.json
@@ -54,8 +54,9 @@
     "key_vault": {
       "type": "string",
       "defaultValue": "",
-      "displayName": "Key vault containing connection string",
-      "description": "Key vault containing connection string"
+      "metadata": {
+        "description": "Key vault containing connection string"
+      }
     }
   },
   "variables": {

--- a/vm/azuredeploy.json
+++ b/vm/azuredeploy.json
@@ -46,9 +46,16 @@
     },
     "autoarmProcesses": {
       "type": "string",
+      "defaultValue": "DSF_Insights",
       "metadata": {
         "description": "Comma-separated list of processes to automatically arm when provisioning the VM"
       }
+    },
+    "key_vault": {
+      "type": "string",
+      "defaultValue": "",
+      "displayName": "Key vault containing connection string",
+      "description": "Key vault containing connection string"
     }
   },
   "variables": {
@@ -101,6 +108,10 @@
               {
                 "name": "autoarm_processes",
                 "value": "[parameters('autoarmProcesses')]"
+              },
+              {
+                "name": "key_vault",
+                "value": "[parameters('key_vault')]"
               }
             ]
           }


### PR DESCRIPTION
Cloud orchestrator doesn't seem to allow calls without account name in the URL anymore

The other fix is for a wrong redirect URL in the cloud invite

In azuredeploy, wanted to play around with the MSI locally - this is more of a coincidental change ;)